### PR TITLE
Update entityId regex pattern to match example

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4011,7 +4011,7 @@ components:
         comprise of the characters -_:.@a-zA-Z0-9!#$%&*+/=?^`{'
       minLength: 1
       maxLength: 128
-      pattern: '-\_:.@a-zA-Z0-9!#\$%&\''\*+/=?^`{'
+      pattern: '[-\_:.@a-zA-Z0-9!#\$%&\''\*+/=?^`{]+'
       example: u-3593dece-6642-4cdc-8547-aafc1454e0a0
     entityType:
       type: string


### PR DESCRIPTION
The current pattern for `entityId` isn't correct. According to the OpenAPI (Swagger) [spec](https://swagger.io/docs/specification/data-models/data-types/#pattern), the pattern is [ECMA 262](https://www.ecma-international.org/ecma-262/5.1/#sec-15.10.1). While the current pattern is valid, it doesn't match the given example. 

This PR wraps the existing pattern with a `[]+` so that we match the given list of characters one or more times. That makes the given example match the pattern. See https://regex101.com/r/3WvRlr/1